### PR TITLE
Include `movementDate` in API responses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,7 +28,7 @@ Layout/SpaceInsideArrayLiteralBrackets:
     - 'config/environments/production.rb'
 
 RSpec/ExampleLength:
-  Max: 11
+  Max: 12
 
 RSpec/NestedGroups:
   Max: 4

--- a/app/views/prison_api/api/movements/by_date.json.jbuilder
+++ b/app/views/prison_api/api/movements/by_date.json.jbuilder
@@ -4,6 +4,7 @@ json.array!(@movements) do |movement|
   json.fromAgency movement.from_prison.code if movement.from_prison
   json.toAgency movement.to_prison.code
   json.createDateTime movement.date.to_datetime
+  json.movementDate movement.date
   json.offenderNo movement.offender.offenderNo
   json.movementType movement.typecode
   json.directionCode movement.directionCode

--- a/app/views/prison_api/api/movements/index.json.jbuilder
+++ b/app/views/prison_api/api/movements/index.json.jbuilder
@@ -4,6 +4,7 @@ json.array!(@movements) do |movement|
   json.fromAgency movement.from_prison.code if movement.from_prison
   json.toAgency movement.to_prison.code
   json.createDateTime movement.date.to_datetime
+  json.movementDate movement.date
   json.offenderNo movement.offender.offenderNo
   json.movementType movement.typecode
   json.directionCode movement.directionCode

--- a/spec/controllers/prison_api/api/movements_controller_spec.rb
+++ b/spec/controllers/prison_api/api/movements_controller_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe PrisonApi::Api::MovementsController, type: :controller do
     let(:m1) {
       {
       toAgency: prison.code,
-      createDateTime: JSON.parse(offender.movements.first.date.to_datetime.to_json),
-      movementDate: JSON.parse(offender.movements.first.date.to_json),
+      createDateTime: offender.movements.first.date.to_datetime,
+      movementDate: offender.movements.first.date,
       movementType: "ADM",
       directionCode: "IN",
       offenderNo: offender.offenderNo,
@@ -29,8 +29,8 @@ RSpec.describe PrisonApi::Api::MovementsController, type: :controller do
       {
         fromAgency: prison.code,
         toAgency: prison2.code,
-        createDateTime: JSON.parse(movement.date.to_datetime.to_json),
-        movementDate: JSON.parse(movement.date.to_json),
+        createDateTime: movement.date.to_datetime,
+        movementDate: movement.date,
         movementType: "TRN",
         directionCode: "IN",
         offenderNo: offender.offenderNo,
@@ -41,7 +41,7 @@ RSpec.describe PrisonApi::Api::MovementsController, type: :controller do
       get :by_date, params: { fromDateTime: 1.day.ago, movementDate: Time.zone.today }, format: :json
       expect(response).to have_http_status(:success)
       expect(JSON.parse(response.body)).
-        to eq([m1, m2].map(&:stringify_keys))
+        to eq(JSON.parse([m1, m2].to_json))
     end
   end
 end

--- a/spec/controllers/prison_api/api/movements_controller_spec.rb
+++ b/spec/controllers/prison_api/api/movements_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe PrisonApi::Api::MovementsController, type: :controller do
       {
       toAgency: prison.code,
       createDateTime: JSON.parse(offender.movements.first.date.to_datetime.to_json),
+      movementDate: JSON.parse(offender.movements.first.date.to_json),
       movementType: "ADM",
       directionCode: "IN",
       offenderNo: offender.offenderNo,
@@ -29,6 +30,7 @@ RSpec.describe PrisonApi::Api::MovementsController, type: :controller do
         fromAgency: prison.code,
         toAgency: prison2.code,
         createDateTime: JSON.parse(movement.date.to_datetime.to_json),
+        movementDate: JSON.parse(movement.date.to_json),
         movementType: "TRN",
         directionCode: "IN",
         offenderNo: offender.offenderNo,

--- a/spec/requests/movements_spec.rb
+++ b/spec/requests/movements_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "Movements", type: :request do
         to eq([{
                  toAgency: prison.code,
                  createDateTime: JSON.parse(offender.movements.first.date.to_datetime.to_json),
+                 movementDate: JSON.parse(offender.movements.first.date.to_json),
                  movementType: "ADM",
                  directionCode: "IN",
                  offenderNo: offender.offenderNo,

--- a/spec/requests/movements_spec.rb
+++ b/spec/requests/movements_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe "Movements", type: :request do
       expect(response).to have_http_status(:success)
 
       expect(JSON.parse(response.body)).
-        to eq([{
+        to eq(JSON.parse([{
                  toAgency: prison.code,
-                 createDateTime: JSON.parse(offender.movements.first.date.to_datetime.to_json),
-                 movementDate: JSON.parse(offender.movements.first.date.to_json),
+                 createDateTime: offender.movements.first.date.to_datetime,
+                 movementDate: offender.movements.first.date,
                  movementType: "ADM",
                  directionCode: "IN",
                  offenderNo: offender.offenderNo,
-               }].map(&:stringify_keys))
+               }].to_json))
     end
   end
 end


### PR DESCRIPTION
The Prison Movement API includes a `movementDate` field in the response which is the date (not date-time) of the movement.

MPC depends on this field being present for things like determining when an offender moved into their current prison.