### PR TITLE
Add agencyId to user role view

### DIFF
--- a/app/views/prison_api/api/users/roles.json.jbuilder
+++ b/app/views/prison_api/api/users/roles.json.jbuilder
@@ -3,4 +3,5 @@
 json.array!(@users) do |user|
   json.extract! user, :staffId, :firstName, :lastName, :position
   json.positionDescription user.position == "PO" ? "Probation Officer" : "Prison Officer"
+  json.agencyId params[:prison_id]
 end

--- a/spec/controllers/prison_api/api/users_controller_spec.rb
+++ b/spec/controllers/prison_api/api/users_controller_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe PrisonApi::Api::UsersController, type: :controller do
         get :roles, params: { prison_id: prison.code }, format: :json
         expect(response).to have_http_status(:success)
         expect(JSON.parse(response.body))
-            .to eq([{ staffId: user.staffId,
+            .to eq([{ agencyId: prison.code,
+                      staffId: user.staffId,
                       position: user.position,
                       positionDescription: "Probation Officer",
                       firstName: user.firstName,


### PR DESCRIPTION
Update roles.json.builder to include the agencyId as we now rely on this field when calculating POM caseloads