### PR TITLE
MO-265 Add CellLocation to the PrisonerSearch API emulation

### DIFF
--- a/app/views/offenders/search.json.jbuilder
+++ b/app/views/offenders/search.json.jbuilder
@@ -3,4 +3,5 @@
 json.array!(@offenders) do |offender|
   json.prisonerNumber offender.offenderNo
   json.recall offender.recall_flag
+  json.cellLocation offender.cellLocation
 end

--- a/spec/controllers/offenders_controller_spec.rb
+++ b/spec/controllers/offenders_controller_spec.rb
@@ -16,18 +16,26 @@ RSpec.describe OffendersController, type: :controller do
   render_views
 
   describe "search" do
+    let(:o1) {
+      {
+        "prisonerNumber" => first_offender.offenderNo,
+        "recall" => false,
+        "cellLocation" => first_offender.cellLocation,
+      }
+    }
+    let(:o2) {
+      {
+        "prisonerNumber" => last_offender.offenderNo,
+        "recall" => false,
+        "cellLocation" => last_offender.cellLocation,
+      }
+    }
+
     it "returns the offenders" do
       post :search, body: { prisonerNumbers: [offenders.map(&:offenderNo)] }.to_json, format: :json
       expect(response).to be_successful
       expect(JSON.parse(response.body))
-        .to match_array([{
-                   "prisonerNumber" => first_offender.offenderNo,
-                   "recall" => false,
-                 },
-                         {
-                           "prisonerNumber" => last_offender.offenderNo,
-                            "recall" => false,
-                         }])
+        .to match_array([o1, o2])
     end
   end
 


### PR DESCRIPTION
It seems like a good plan to slowly move over to the PrisonerSearch API - however attempting to do this in a 'big bang' didn't really work out. 

So as an alternative, start tp pick up little bits from it as we go along - cellLocation is new (and scattered in the Prison API) so it seems like a useful place to start