### PR TITLE
Upgrade mimemagic gem to fix build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /yarn-error.log
 
 .byebug_history
+Brewfile.lock.json
 /coverage/
 .ruby-gemset
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ AllCops:
     - 'db/schema.rb'
     - 'spec/rails_helper.rb'
     - 'bin/*'
+    - 'Brewfile'
 
 # Offense count: 2
 # Cop supports --auto-correct.

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,13 @@
+# Brewfile: a Gemfile, but for Homebrew
+#
+# Install the dependencies in this file by running:
+# brew bundle
+#
+# Read more about Brewfiles here:
+# https://thoughtbot.com/blog/brewfile-a-gemfile-but-for-homebrew
+
+# required by Rails Active Record
+brew 'postgres'
+
+# required by gem 'mimemagic' v0.3.9
+brew 'shared-mime-info'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)


### PR DESCRIPTION
The previous version of mimemagic (0.3.6) has been yanked from the Ruby Gems repo due to a licencing issue.

This commit updates to use 0.3.10 instead, which should get things building again.