### PR TITLE
Configure git crypt in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,42 +57,42 @@ references:
         /usr/libexec/gpg-preset-passphrase --preset --passphrase $GPG_PASSPHRASE $GPG_KEY_KEYGRIP_ID
         git-crypt unlock
 
-    install_aws_cli: &install_aws_cli
-      run:
-        name: Set up aws
-        command: |
-          sudo apt-get update
-          sudo apt-get --assume-yes install python3-pip
-          sudo pip3 install awscli
+  install_aws_cli: &install_aws_cli
+    run:
+      name: Set up aws
+      command: |
+        sudo apt-get update
+        sudo apt-get --assume-yes install python3-pip
+        sudo pip3 install awscli
 
-    build_docker_image: &build_docker_image
-      run:
-        name: Build docker image
-        command: |
-          export BUILD_DATE=$(date -Is) >> $BASH_ENV
-          source $BASH_ENV
-          docker build \
-            --build-arg VERSION_NUMBER=${CIRCLE_BUILD_NUM} \
-            --build-arg COMMIT_ID=${CIRCLE_SHA1} \
-            --build-arg BUILD_DATE=${BUILD_DATE} \
-            --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
-            -t app .
+  build_docker_image: &build_docker_image
+    run:
+      name: Build docker image
+      command: |
+        export BUILD_DATE=$(date -Is) >> $BASH_ENV
+        source $BASH_ENV
+        docker build \
+          --build-arg VERSION_NUMBER=${CIRCLE_BUILD_NUM} \
+          --build-arg COMMIT_ID=${CIRCLE_SHA1} \
+          --build-arg BUILD_DATE=${BUILD_DATE} \
+          --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
+          -t app .
 
-    push_docker_image: &push_docker_image
-      run:
-        name: Push docker image
-        command: |
-          login="$(aws ecr get-login --region eu-west-2 --no-include-email)"
-          ${login}
-          docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
-          docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
-          if [ "${CIRCLE_BRANCH}" == "main" ]; then
-            docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
-            docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
-          fi
-        environment:
-          <<: *github_team_name_slug
-          REPONAME: nomis-delius-emulator
+  push_docker_image: &push_docker_image
+    run:
+      name: Push docker image
+      command: |
+        login="$(aws ecr get-login --region eu-west-2 --no-include-email)"
+        ${login}
+        docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
+        docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:${CIRCLE_SHA1}"
+        if [ "${CIRCLE_BRANCH}" == "main" ]; then
+          docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
+          docker push "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${REPONAME}:latest"
+        fi
+      environment:
+        <<: *github_team_name_slug
+        REPONAME: nomis-delius-emulator
 
 version: 2.1
 jobs:
@@ -167,9 +167,10 @@ jobs:
           command: |
             setup-kube-auth
             kubectl config use-context staging
-#      - *install_gpg
-#      - *configure_gpg
-      - deploy:
+      - *install_gpg
+      - *configure_gpg
+      - *decrypt_secrets
+      - run:
           name: Deploy to K8s
           command: |
             sed -i -e s/:latest/:$CIRCLE_SHA1/ deploy/deployment.yaml


### PR DESCRIPTION
This allows CircleCI to run `git-crypt unlock` to access secrets required for deployment.