### PR TITLE
Upgrade assessments category endpoint to reflect usage in MPC

### DIFF
--- a/app/views/prison_api/api/offenders/assessments.json.jbuilder
+++ b/app/views/prison_api/api/offenders/assessments.json.jbuilder
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
 json.array!(@offenders) do |offender|
+  json.offenderNo offender.offenderNo
   json.classificationCode offender.categoryCode
+  json.classification "Cat #{offender.categoryCode}"
+  json.approvalDate offender.updated_at.to_date
 end

--- a/app/views/prison_api/api/offenders/index.json.jbuilder
+++ b/app/views/prison_api/api/offenders/index.json.jbuilder
@@ -2,7 +2,7 @@
 
 json.array!(@offenders) do |offender|
   json.extract! offender,
-                :categoryCode, :mainOffence, :receptionDate,
+                :mainOffence, :receptionDate,
                 :firstName, :lastName, :offenderNo, :dateOfBirth,
                 :imprisonmentStatus
   json.bookingId offender.booking_id

--- a/spec/controllers/prison_api/api/offenders_controller_spec.rb
+++ b/spec/controllers/prison_api/api/offenders_controller_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe PrisonApi::Api::OffendersController, type: :controller do
     let!(:offender_no_location) { create(:offender, cellLocation: nil, prison: prison, booking: build(:booking)) }
     let(:offender_json) {
       {
-        categoryCode: nil,
         firstName: offender.firstName,
         bookingId: offender.booking.id,
         agencyId: prison.code,
@@ -41,7 +40,6 @@ RSpec.describe PrisonApi::Api::OffendersController, type: :controller do
     }
     let(:no_location_json) {
       {
-        categoryCode: nil,
         firstName: offender_no_location.firstName,
         bookingId: offender_no_location.booking.id,
         agencyId: prison.code,
@@ -70,10 +68,13 @@ RSpec.describe PrisonApi::Api::OffendersController, type: :controller do
 
     render_views
 
-    it "assessments endpoint returns classification code" do
+    it "assessments endpoint returns category code" do
       post :assessments, body: [offender.offenderNo].to_json, format: :json
       expect(response).to be_successful
-      expect(JSON.parse(response.body)).to eq([{ "classificationCode" => nil }])
+      expect(JSON.parse(response.body)).to eq([{ offenderNo: offender.offenderNo,
+                                                 classificationCode: "C",
+                                                 classification: "Cat C",
+                                                 approvalDate: offender.updated_at.to_date.to_s }.stringify_keys])
     end
 
     it "gets index" do

--- a/spec/factories/offenders.rb
+++ b/spec/factories/offenders.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :offender do
     association :prison
 
+    categoryCode { "C" }
     firstName { "Fred" }
     imprisonmentStatus { "SENT03" }
     lastName { "Bloggs" }


### PR DESCRIPTION
This is to fix https://sentry.io/organizations/ministryofjustice/issues/2365999704/?project=5584204&query=is%3Aunresolved