### PR TITLE
Exclude offenders missing a category

### DIFF
--- a/app/controllers/prison_api/api/offenders_controller.rb
+++ b/app/controllers/prison_api/api/offenders_controller.rb
@@ -22,6 +22,7 @@ module PrisonApi
       def assessments
         offender_ids = JSON.parse(request.body.string)
         @offenders = Offender.where(offenderNo: offender_ids)
+                             .select { |o| o.categoryCode.present? }
       end
     end
   end


### PR DESCRIPTION
This commit stops the `/offender-assessments/CATEGORY` endpoint from including responses for offenders who don't have a category code. This reflects actual behaviour of the Prison API.

This builds upon the functionality added in #55.